### PR TITLE
DOCU-704 Adding and labeling Preview file system types.

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -144,6 +144,58 @@ filesystem add adls2 sharedKey --file-system-id mytarget --storage-account-name 
 
 ----
 
+### `filesystem add gcs`
+
+:::caution
+Google Cloud Storage functionality is available as a preview and is not yet a supported configuration.
+:::
+
+
+Add a Google Cloud Storage as a migration target using the `filesystem add gcs` command, which requires credentials in the form of an account key file.
+
+```text title="Add an ADLS Gen 2 file system"
+SYNOPSYS
+        filesystem add gcs  [--file-system-id] string
+                            [--service-account-key-file] string
+                            [--bucket-name] string
+                            [[--properties-file] list]
+                            [[--properties] list]
+
+OPTIONS
+        --file-system-id  string
+
+                [Mandatory]
+
+        --service-account-key-file  string
+
+                [Mandatory]
+
+        --bucket-name  string
+
+                [Mandatory]
+
+        --properties-file  list
+                Load properties from this file
+                [Optional, default = <none>]
+
+        --properties  list
+                Override properties in comma separated key/value list
+                [Optional, default = <none>]
+```
+
+#### Mandatory Parameters
+
+* **`--file-system-id`** The identifier to give the new file system resource.
+* **`--service-account-key-file`** The path to a Service Account Key file.
+* **`--bucket-name`** The bucket name of a Google Cloud Storage account.
+
+#### Optional Parameters
+
+* **`--properties-files`** Reference a list of existing properties files, each that contains Hadoop configuration properties in the format used by `core-site.xml` or `hdfs-site.xml`.
+* **`--properties`** Specify properties to use in a comma-separated key/value list.
+
+----
+
 ### `filesystem add hdfs`
 
 Add a Hadoop Distributed File System as either a migration source or target using the `filesystem add hdfs` command.
@@ -216,6 +268,10 @@ filesystem add hdfs --file-system-id mysource --source --fs.defaultFS hdfs://myn
 
 ### `filesystem add local`
 
+:::caution
+Local file system functionality is available as a preview and is not yet a supported configuration.
+:::
+
 Add a local file system as either a migration source or target using the `filesystem add local` command.
 
 ```text title="Add a local file system"
@@ -256,7 +312,6 @@ OPTIONS
 
 * **`--fs-root`** The path to a location in the file system to treat as the root from which content will be migrated.
 * **`--source`** Provide this parameter to use the file system resource created as a source.
-  * UI: Defined when choosing the **Add Source** option.
 * **`--properties-files`** Reference a list of existing properties files, each that contains Hadoop configuration properties in the format used by `core-site.xml` or `hdfs-site.xml`.
 * **`--properties`** Specify properties to use in a comma-separated key/value list.
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -153,7 +153,7 @@ Google Cloud Storage functionality is available as a preview and is not yet a su
 
 Add a Google Cloud Storage as a migration target using the `filesystem add gcs` command, which requires credentials in the form of an account key file.
 
-```text title="Add an ADLS Gen 2 file system"
+```text title="Add a Google Cloud Storage file system"
 SYNOPSYS
         filesystem add gcs  [--file-system-id] string
                             [--service-account-key-file] string

--- a/docs/operation-cli.md
+++ b/docs/operation-cli.md
@@ -93,9 +93,14 @@ If your source file system was not discovered automatically or you wish to assig
 
 You can define multiple target file systems, which you can migrate to at the same time.
 
+:::caution
+Local file system and Google Cloud Storage functionality are available as a preview and is not yet a supported configuration.
+:::
+
 | Command | Action |
 |:---|:---|
 | [`filesystem add adls2 sharedKey`](./command-reference.md#filesystem-add-adls2-sharedkey) | Add an ADLS Gen 2 file system resource |
+| [`filesystem add gcs`](./command-reference.md#filesystem-add-gcs) | Add a Google Cloud Storage file system resource |
 | [`filesystem add hdfs`](./command-reference.md#filesystem-add-hdfs) | Add a Hadoop HDFS file system resource |
 | [`filesystem add local`](./command-reference.md#filesystem-add-local) | Add a local file system resource |
 | [`filesystem add s3a`](./command-reference.md#filesystem-add-s3a) | Add an S3 file system resource |


### PR DESCRIPTION
GCS was absent from documentation but now that we're labelling it as a Preview type I thought it was worth including.