### PR TITLE
Documented non-live migrations in UI

### DIFF
--- a/docs/create-migration.md
+++ b/docs/create-migration.md
@@ -56,6 +56,6 @@ Follow the command links to learn how to set the parameters and see examples.
 
 ### Create a non-live migration
 
-It's possible to create a migration that does not track client activity: if files are changed during the migration process, they will not be re-scanned by LiveData Migrator.
+Create a non-live migration if you do not want LiveData Migrator to scan for changes to your data during a migration. These migrations do not require you to have write access to the source filesystem, nor do they require you to operate the migration as the `hdfs` user.
 
-For more information, see [create a non-live migration](./non-live-migration.md).
+To create a non-live migration, see [create a non-live migration](./non-live-migration.md).

--- a/docs/create-migration.md
+++ b/docs/create-migration.md
@@ -53,35 +53,9 @@ Follow the command links to learn how to set the parameters and see examples.
 
    [`migration run`](./command-reference.md#migration-run)
 
+
 ### Create a non-live migration
 
-A non-live migration is a migration that does not track client activity: if files are changed during the migration process, they will not be re-scanned by LiveData Migrator. There are two ways to create a non-live migration through the CLI:
+It's possible to create a migration that does not track client activity: if files are changed during the migration process, they will not be re-scanned by LiveData Migrator.
 
-1. Start a migration with a [non-live source file system](#create-a-non-live-source-file-system)
-1. Specify the [`scanOnly` flag](#specify-the-scanonly-flag-during-migration-creation) during migration creation
-
-:::note
-A non-live migration does not read events from the source file system, and does not write a [marker file](./configuration-ldm.md/#hdfs-marker-storage) to the source file system. Once the scan of the source file system completes (to determine which files and directories are to be migrated), the migration will enter a `COMPLETED` [data migration state](./manage-migrations.md/#data-migration-states) and carry out no further scanning.
-:::
-
-#### Create a non-live source file system
-
-LiveData Migrator will only perform *read* tasks on a non-live source, and will not check the source for modifications to data during transfer. Any migration that uses a non-live source will automatically become a non-live migration, and will have the `scanOnly` flag applied.
-
-To create a non-live source, add the `scanOnly` flag during source creation:
-
-```text="Code"
-filesystem add hdfs --source --scanOnly ...
-```
-
-:::note
-The account used to connect to a non-live source only requires read access. Write access is not necessary.
-:::
-
-#### Specify the scanOnly flag during migration creation
-
-To create a non-live migration without creating a non-live source file system, simply add the `scanOnly` flag during migration creation:
-
-```text="Code"
-migration add --scanOnly ...
-```
+For more information, see [create a non-live migration](./non-live-migration.md).

--- a/docs/non-live-migration.md
+++ b/docs/non-live-migration.md
@@ -1,0 +1,66 @@
+---
+id: non-live-migration
+title: Create a Non-Live Migration
+sidebar_label: Create a non-live migration
+---
+
+A non-live migration is a migration that does not track client activity: if files are changed during the migration process, they will not be re-scanned by LiveData Migrator.
+
+:::note
+A non-live migration does not track events from the source file system, and does not write a [marker file](./configuration-ldm.md/#hdfs-marker-storage) to the source file system. Once the scan of the source file system completes (to determine which files and directories are to be migrated), the migration will enter a `COMPLETED` [data migration state](./manage-migrations.md/#data-migration-states) and carry out no further scanning.
+
+This means you can perform non-live migrations without write access, and without the need to operate the migration as the `hdfs` user.
+:::
+
+## Create a non-live migration
+
+Non-live migrations may be created through the UI or through the CLI.
+
+### Create a non-live migration with the UI
+
+To create a non-live migration through the CLI, simply deselect the "Live Migration" option when creating a migration. Unlike a live migration, this migration will not state that it is live. When in progress, the migration will inform you that you must rerun the migration to see new changes.
+
+### Create a non-live migration with the CLI
+
+A non-live migration is a migration that does not track client activity: if files are changed during the migration process, they will not be re-scanned by LiveData Migrator. There are two ways to create a non-live migration through the CLI:
+
+1. Start a migration with a [non-live source file system](#create-a-non-live-source)
+1. Specify the `scanOnly` flag during migration creation:
+
+```text="Code"
+migration add --scanOnly ...
+```
+
+:::note
+A non-live migration does not read events from the source file system, and does not write a [marker file](./configuration-ldm.md/#hdfs-marker-storage) to the source file system. Once the scan of the source file system completes (to determine which files and directories are to be migrated), the migration will enter a `COMPLETED` [data migration state](./manage-migrations.md/#data-migration-states) and carry out no further scanning.
+:::
+
+## Create a non-live source
+
+A non-live source is a filesystem that is not tracked by LiveData Migrator for changes during a migration.
+
+:::note
+Any migration created from a non-live source via the CLI will become a non-live migration by default, whereas the UI will uncheck the "live migration" option by default and prevent it from being enabled.
+:::
+
+Non-live sources may be created through the UI or through the CLI.
+
+### Create a non-live source with the UI
+
+To create a non-live source, simply uncheck the "Migrate Live Events" box during source creation.
+
+When creating a migration from a non-live source, "Live Migration" will be unchecked by default and cannot be enabled.
+
+### Create a non-live source file system with the CLI
+
+LiveData Migrator will only perform *read* tasks on a non-live source, and will not check the source for modifications to data during transfer. Any migration that uses a non-live source will automatically become a non-live migration, and will have the `scanOnly` flag applied.
+
+To create a non-live source, add the `scanOnly` flag during source creation:
+
+```text="Code"
+filesystem add hdfs --source --scanOnly ...
+```
+
+:::note
+The account used to connect to a non-live source only requires read access. Write access is not necessary.
+:::

--- a/docs/non-live-migration.md
+++ b/docs/non-live-migration.md
@@ -4,25 +4,25 @@ title: Create a Non-Live Migration
 sidebar_label: Create a non-live migration
 ---
 
-A non-live migration is a migration that does not track client activity: if files are changed during the migration process, they will not be re-scanned by LiveData Migrator.
+A non-live migration is a migration that does not track activity in the source filesystem. LiveData Migrator will not scan your data for updates during non-live migrations.
 
 :::note
-A non-live migration does not track events from the source file system, and does not write a [marker file](./configuration-ldm.md/#hdfs-marker-storage) to the source file system. Once the scan of the source file system completes (to determine which files and directories are to be migrated), the migration will enter a `COMPLETED` [data migration state](./manage-migrations.md/#data-migration-states) and carry out no further scanning.
+A non-live migration does not track events from the source file system, and does not write a [marker file](./configuration-ldm.md/#hdfs-marker-storage) to the source file system. Once the scan of the source file system completes (to determine which files and directories are to be migrated), the migration will enter a `COMPLETED` [data migration state](./manage-migrations.md/#data-migration-states) and won't perform any further scans.
 
 This means you can perform non-live migrations without write access, and without the need to operate the migration as the `hdfs` user.
 :::
 
 ## Create a non-live migration
 
-Non-live migrations may be created through the UI or through the CLI.
+You can create a non-live migration with either the UI or the CLI.
 
 ### Create a non-live migration with the UI
 
-To create a non-live migration through the CLI, simply deselect the "Live Migration" option when creating a migration. Unlike a live migration, this migration will not state that it is live. When in progress, the migration will inform you that you must rerun the migration to see new changes.
+To create a non-live migration with the CLI, deselect the "Live Migration" option when creating a migration. Unlike a live migration, this migration won't display a "live" state in the UI. During a migration, the migration tells you that you must rerun it to see new changes.
 
 ### Create a non-live migration with the CLI
 
-A non-live migration is a migration that does not track client activity: if files are changed during the migration process, they will not be re-scanned by LiveData Migrator. There are two ways to create a non-live migration through the CLI:
+There are two ways to create a non-live migration through the CLI:
 
 1. Start a migration with a [non-live source file system](#create-a-non-live-source)
 1. Specify the `scanOnly` flag during migration creation:
@@ -32,7 +32,9 @@ migration add --scanOnly ...
 ```
 
 :::note
-A non-live migration does not read events from the source file system, and does not write a [marker file](./configuration-ldm.md/#hdfs-marker-storage) to the source file system. Once the scan of the source file system completes (to determine which files and directories are to be migrated), the migration will enter a `COMPLETED` [data migration state](./manage-migrations.md/#data-migration-states) and carry out no further scanning.
+Non-live migrations do not read events from the source file system or write [marker files](./configuration-ldm.md/#hdfs-marker-storage) to the source file system.
+
+Once the scan of the source file system (to determine which files and directories are to be migrated) completes, the migration will enter a `COMPLETED` [data migration state](./manage-migrations.md/#data-migration-states) and carry out no further scanning.
 :::
 
 ## Create a non-live source
@@ -40,20 +42,20 @@ A non-live migration does not read events from the source file system, and does 
 A non-live source is a filesystem that is not tracked by LiveData Migrator for changes during a migration.
 
 :::note
-Any migration created from a non-live source via the CLI will become a non-live migration by default, whereas the UI will uncheck the "live migration" option by default and prevent it from being enabled.
+Any migration created from a non-live source will become a non-live migration by default. When creating a migration from the UI in this case, it will uncheck the "live migration" option by default and prevent it from being enabled.
 :::
 
 Non-live sources may be created through the UI or through the CLI.
 
 ### Create a non-live source with the UI
 
-To create a non-live source, simply uncheck the "Migrate Live Events" box during source creation.
+To create a non-live source, uncheck the "Migrate Live Events" box during source creation.
 
 When creating a migration from a non-live source, "Live Migration" will be unchecked by default and cannot be enabled.
 
 ### Create a non-live source file system with the CLI
 
-LiveData Migrator will only perform *read* tasks on a non-live source, and will not check the source for modifications to data during transfer. Any migration that uses a non-live source will automatically become a non-live migration, and will have the `scanOnly` flag applied.
+LiveData Migrator will only perform *read* tasks on a non-live source. It will not check the source for modifications to data during transfer. Any migration that uses a non-live source will automatically become a non-live migration, and will have the `scanOnly` flag applied.
 
 To create a non-live source, add the `scanOnly` flag during source creation:
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -51,6 +51,10 @@ module.exports = {
             },
             {
               "type": "doc",
+              "id": "non-live-migration"
+            },
+            {
+              "type": "doc",
               "id": "configure-exclusions"
             },
 


### PR DESCRIPTION
Instead of continuing to add on to a progressively lengthening "create a migration" page, I added a separate "create a non-live migration" page and moved all of the CLI info over before adding the UI info.

Ticket: https://jira.wandisco.com/browse/DOCU-927