### PR TITLE
Document CLI capabilities to update filesystems

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -200,8 +200,6 @@ OPTIONS
         --properties  string
                 Override properties in comma separated key/value string e.g. --properties property-one=value-one,\"property-two=value-one,value-two\"
                 [Optional, default = <nothing>]
-
-
 ```
 
 #### Mandatory Parameters
@@ -363,17 +361,12 @@ OPTIONS
         --properties  string
                 Override properties in comma separated key/value string e.g. --properties property-one=value-one,\"property-two=value-one,value-two\"
                 [Optional, default = <nothing>]
-
-        --scanOnly
-                Flags the filesystem as a non-live source file system, meaning it will not be checked for changes to data during a migration. Any migrations created with this filesystem as a source will automatically become non-live migrations.
-                [Optional, default = false]
-                [Requires --source]
 ```
 
 #### Mandatory Parameters
 
 * **`--file-system-id`** The identifier to give the new file system resource. This is referenced in the UI as **Storage Name**.
-* **`--fs.defaultFS`** A string that defines how LiveData Migrator accesses HDFS. This is referenced in the UI as **Default FS**.  
+* **`--default-fs`** A string that defines how LiveData Migrator accesses HDFS. This is referenced in the UI as **Default FS**.  
   It can be specified in a number of forms:
   1. As a single HDFS URI, such as `hdfs://192.168.1.10:8020` (using an IP address) or `hdfs://myhost.localdomain:8020` (using a hostname).
   1. As an HDFS URI that references a nameservice ID defined in the cluster properties, like `hdfs://mynameservice`, where there is a configuration property for the cluster that defines the value of the `dfs.nameservices` value to include that nameservice ID, like `mynameservice` and all required configuration properties for that nameservice, like `dfs.ha.namenodes.mynameservice`, `dfs.namenode.rpc-address.mynameservice.nn1`, and `dfs.namenode.http-address.mynameservice.nn1`, etc.
@@ -390,7 +383,7 @@ See the links below for guidance for common Hadoop distributions:
 
 * [CDH](https://docs.cloudera.com/documentation/enterprise/6/6.3/topics/cm_sg_kdc_def_domain_s2.html)
 * [CDP](https://docs.cloudera.com/cdp-private-cloud-base/7.1.5/security-kerberos-authentication/topics/cm-security-kerberos-authentication-kdc-cross-realm-trust.html)
-* [Red Hat](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system-level_authentication_guide/using_trusts)
+* [Red Hat](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system-level_authentication_guide/using_trusts) (Unmanaged)
 * [HDP](https://community.cloudera.com/t5/Community-Articles/Kerberos-cross-realm-trust-for-distcp/ta-p/245590)
 :::
 
@@ -400,7 +393,6 @@ See the links below for guidance for common Hadoop distributions:
 * **`--source`** Provide this parameter to use the file system resource created as a source.  This is referenced in the UI when configuring the _Unknown source_.
 * **`--properties-files`** Reference a list of existing properties files that contain Hadoop configuration properties in the format used by `core-site.xml` or `hdfs-site.xml`.  This is referenced in the UI as **Provide a path to files** under the _Additional Configuration_ option.
 * **`--properties`** Specify properties to use in a comma-separated key/value list. This is referenced in the UI as **Additional Configuration** under the _Additional Configuration_ option.
-* **`--scanOnly`** Flags the filesystem as a [non-live source file system](./create-migration.md/#create-a-non-live-source-file-system). *Only works with a source filesystem*.
 
 ##### Properties files are required for NameNode HA
 
@@ -439,11 +431,11 @@ If your Hadoop cluster has [NameNode HA enabled](https://hadoop.apache.org/docs/
 ##### HDFS as source
 
 ```text title="Example for source NameNode HA cluster"
-filesystem add hdfs --file-system-id mysource --source --fs.defaultFS hdfs://sourcenameservice --properties-files /etc/hadoop/conf/core-site.xml,/etc/hadoop/conf/hdfs-site.xml
+filesystem add hdfs --file-system-id mysource --source --default-fs hdfs://sourcenameservice --properties-files /etc/hadoop/conf/core-site.xml,/etc/hadoop/conf/hdfs-site.xml
 ```
 
 ```text title="Example for source NameNode HA cluster with Kerberos enabled"
-filesystem add hdfs --file-system-id mysource --source --fs.defaultFS hdfs://sourcenameservice --properties-files /etc/hadoop/conf/core-site.xml,/etc/hadoop/conf/hdfs-site.xml --kerberos-keytab /etc/security/keytabs/hdfs.headless.keytab --kerberos-principal hdfs@SOURCEREALM.COM
+filesystem add hdfs --file-system-id mysource --source --default-fs hdfs://sourcenameservice --properties-files /etc/hadoop/conf/core-site.xml,/etc/hadoop/conf/hdfs-site.xml --kerberos-keytab /etc/security/keytabs/hdfs.headless.keytab --kerberos-principal hdfs@SOURCEREALM.COM
 ```
 
 ##### HDFS as target
@@ -453,11 +445,11 @@ When specifying a HDFS filesystem as a target, the property files for the target
 :::
 
 ```text title="Example for target NameNode HA cluster with Kerberos enabled"
-filesystem add hdfs --file-system-id mytarget --fs.defaultFS hdfs://targetnameservice --properties-files /etc/targetClusterConfig/core-site.xml,/etc/targetClusterConfig/hdfs-site.xml --kerberos-keytab /etc/security/keytabs/hdfs.headless.keytab --kerberos-principal hdfs@SOURCEREALM.COM
+filesystem add hdfs --file-system-id mytarget --default-fs hdfs://targetnameservice --properties-files /etc/targetClusterConfig/core-site.xml,/etc/targetClusterConfig/hdfs-site.xml --kerberos-keytab /etc/security/keytabs/hdfs.headless.keytab --kerberos-principal hdfs@SOURCEREALM.COM
 ```
 
 ```text title="Example for target single NameNode cluster"
-filesystem add hdfs --file-system-id mytarget --fs.defaultFS hdfs://namenode.targetdomain:8020 --user hdfs
+filesystem add hdfs --file-system-id mytarget --default-fs hdfs://namenode.targetdomain:8020 --user hdfs
 ```
 
 ----
@@ -691,6 +683,383 @@ SYNOPSYS
         filesystem types
 ```
 
+----
+
+### `filesystem update adls2 oauth`
+
+Update an existing Azure Data Lake Storage Gen 2 container migration target with a specified filesystem ID using the `filesystem update adls2 oauth` command. You will be prompted to optionally update the [service principal](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal) and [OAuth 2](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols) credentials.
+
+Any optional parameters supplied will update the corresponding details of the existing filesystem.
+
+```text title="Update an ADLS2 FileSystem via HCFS API FileSystem With OAuth"
+SYNOPSYS
+        filesystem update adls2 oauth [--file-system-id] string
+                                   [--storage-account-name] string
+                                   [--oauth2-client-id] string
+                                   [--oauth2-client-secret] string
+                                   [--oauth2-client-endpoint] string
+                                   [--container-name] string
+                                   [--insecure]
+                                   [[--properties-files] list]
+                                   [[--properties] string]
+
+OPTIONS
+        --file-system-id  string
+
+                [Mandatory]
+
+        --storage-account-name  string
+
+                [Optional, default = <none>]
+
+        --oauth2-client-id  string
+
+                [Optional, default = <none>]
+
+        --oauth2-client-secret  string
+
+                [Optional, default = <none>]
+
+        --oauth2-client-endpoint  string
+
+                [Optional, default = <none>]
+
+        --container-name  string
+
+                [Optional, default = <none>]
+
+        --insecure
+                [Optional, default = false]
+
+        --properties-files  list
+                Load properties from this file
+                [Optional, default = <none>]
+
+        --properties  string
+                Override properties in comma separated key/value string e.g. --properties property-one=value-one,\"property-two=value-one,value-two\"
+                [Optional, default = <nothing>]
+```
+
+#### Mandatory Parameters
+
+* **`--file-system-id`** The identifier of the existing file system resource to update. This is referenced in the UI as **Storage Name**.
+
+#### Optional Parameters
+
+* **`--storage-account-name`** The name of the ADLS Gen 2 storage account to target. This is referenced in the UI as **Account Name**.
+* **`--oauth2-client-id`** The client ID (also known as [application ID](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal#get-tenant-and-app-id-values-for-signing-in)) for your Azure service principal. This is referenced in the UI as **Client ID**.
+* **`--oauth2-client-secret`** The client secret (also known as [application secret](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal#option-2-create-a-new-application-secret)) for the Azure service principal. This is referenced in the UI as **Secret**.
+* **`--oauth2-client-endpoint`** The [client endpoint](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols#endpoints) for the Azure service principal. This is referenced in the UI as **Endpoint**.  
+This will often take the form of `https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token` where `{tenant}` is the [directory ID](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal#get-tenant-and-app-id-values-for-signing-in) for the Azure service principal. You can specify a custom URL if desired (such as a proxy endpoint that manually interfaces with Azure Active Directory).
+* **`--container.name`** The name of the container in the storage account to which content will be migrated. This is referenced in the UI as **Container Name**.
+* **`--insecure`** When provided, LiveData Migrator will not use TLS to encrypt communication with ADLS Gen 2. This may improve throughput, but should only be used when you have other means of securing communication. This is referenced in the UI when **Use Secure Protocol** is unchecked.
+* **`--properties-files`** Reference a list of existing properties files, each that contains Hadoop configuration properties in the format used by `core-site.xml` or `hdfs-site.xml`.
+* **`--properties`** Specify properties to use in a comma-separated key/value list.
+
+#### Example
+
+```text
+filesystem update adls2 oauth --file-system-id mytarget --storage-account-name myadls2 --oauth2-client-id b67f67ex-ampl-e2eb-bd6d-client9385id --oauth2-client-secret 2IPO8*secretk-9OPs8n*TexampleHJ= --oauth2-client-endpoint https://login.microsoftonline.com/78u098ex-ampl-e498-8bce-ndpoint5f2e5/oauth2/v2.0/token --container.name lm2target
+```
+
+----
+
+### `filesystem update adls2 sharedKey`
+
+Update an existing Azure Data Lake Storage Gen 2 container migration target using the `filesystem update adls2 sharedKey` command. You will be prompted to optionally update the [secret key](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage?tabs=azure-portal#view-account-access-keys).
+
+Any optional parameters supplied will update the corresponding details of the existing filesystem.
+
+```text title="Update an ADLS2 FileSystem via HCFS API FileSystem With Shared Key"
+SYNOPSYS
+        filesystem update adls2 sharedKey [--file-system-id] string
+                                       [--storage-account-name] string
+                                       [--shared-key] string
+                                       [--container-name] string
+                                       [--insecure]
+                                       [[--properties-files] list]
+                                       [[--properties] string]
+
+OPTIONS
+        --file-system-id  string
+
+                [Mandatory]
+
+        --storage-account-name  string
+
+                [Optional, default = <none>]
+
+        --shared-key  string
+
+                [Optional, default = <none>]
+
+        --container-name  string
+
+                [Optional, default = <none>]
+
+        --insecure
+                [Optional, default = false]
+
+        --properties-files  list
+                Load properties from these files
+                [Optional, default = <none>]
+
+        --properties  string
+                Override properties in comma separated key/value string e.g. --properties property-one=value-one,\"property-two=value-one,value-two\"
+                [Optional, default = <none>]
+```
+
+#### Mandatory Parameters
+
+* **`--file-system-id`** The identifier of the existing file system resource to update. This is referenced in the UI as **Storage Name**.
+
+#### Optional Parameters
+
+* **`--storage-account-name`** The name of the ADLS Gen 2 storage account to target. This is referenced in the UI as **Account Name**.
+* **`--shared.key`** The [shared account key](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage?tabs=azure-portal#view-account-access-keys) to use as credentials to write to the storage account. This is referenced in the UI as **Access Key**.
+* **`--container.name`** The name of the container in the storage account to which content will be migrated. This is referenced in the UI as **Container Name**.
+* **`--insecure`** When provided, LiveData Migrator will not use TLS to encrypt communication with ADLS Gen 2. This may improve throughput, but should only be used when you have other means of securing communication. This is referenced in the UI when **Use Secure Protocol** is unchecked.
+* **`--properties-files`** Reference a list of existing properties files, each that contains Hadoop configuration properties in the format used by `core-site.xml` or `hdfs-site.xml`.
+* **`--properties`** Specify properties to use in a comma-separated key/value list.
+
+#### Example
+
+```text
+filesystem update adls2 sharedKey --file-system-id mytarget --storage-account-name myadls2 --container.name lm2target --shared.key Yi8NxHGqoQ79DBGLVn+COK/sRDwbNqAEXAMPLEDaMxRkvXt2ijUtASHAREDj/vaS/NbzR5rtjEKEY31eIopUVA==
+```
+
+----
+
+### `filesystem update gcs`
+
+Update a Google Cloud Storage migration target using the `filesystem update gcs` command.
+
+Any optional parameters supplied will update the corresponding details of the existing filesystem.
+
+```text title="Update a Google Cloud Storage file system"
+SYNOPSYS
+        filesystem update gcs [--file-system-id] string
+                           [[--service-account-json-key-file] string]
+                           [[--service-account-p12-key-file] string]
+                           [[--service-account-json-key-file-server-location] string]
+                           [[--service-account-p12-key-file-server-location] string]
+                           [[--service-account-email] string]
+                           [--bucket-name] string
+                           [[--properties-files] list]
+                           [[--properties] string]
+
+OPTIONS
+        --file-system-id  string
+
+                [Mandatory]
+
+        --service-account-json-key-file  string
+
+                [Optional, default = <none>]
+
+        --service-account-p12-key-file  string
+
+                [Optional, default = <none>]
+
+        --service-account-json-key-file-server-location  string
+                Permanent location of the GCS KeyFile on the LiveData Migrator server
+                [Optional, default = <none>]
+
+        --service-account-p12-key-file-server-location  string
+                Permanent location of the GCS KeyFile on the LiveData Migrator server
+                [Optional, default = <none>]
+
+        --service-account-email  string
+                GCS Service Account Email
+                [Optional, default = <none>]
+
+        --bucket-name  string
+
+                [Optional, default = <none>]
+
+        --properties-files  list
+                Load properties from these files
+                [Optional, default = <nothing>]
+
+        --properties  string
+                Override properties in comma separated key/value string e.g. --properties property-one=value-one,\"property-two=value-one,value-two\"
+                [Optional, default = <nothing>]
+```
+
+#### Mandatory Parameters
+
+* **`--file-system-id`** The identifier of the file system resource to update. This is referenced in the UI as **Storage Name**.
+
+
+
+
+#### Optional Parameters
+
+* **`--bucket-name`** The bucket name of a Google Cloud Storage account. This is referenced in the UI as **Bucket Name**.
+* **`--service-account-email`** The email address linked to your GCS service account. This is referenced in the UI as **Email address** and is required when selecting the **Upload P12 Key File** option.
+* **`--properties-files`** Reference a list of existing properties files, each that contains Hadoop configuration properties in the format used by `core-site.xml` or `hdfs-site.xml`.
+* **`--properties`** Specify properties to use in a comma-separated key/value list.
+
+#### Service account key parameters
+
+:::info
+Provide your service account key for the GCS bucket by choosing one of the parameters below.
+
+You can also upload the service account key directly when using the UI (this is not supported through the CLI).
+:::
+
+* **`--service-account-json-key-file-server-location`** The absolute filesystem path on the LiveData Migrator server of your service account key file in JSON format. You can either [create a GCS service account key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys) or [use an existing one](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#listing_service_account_keys).  
+This is referenced in the UI as **Key File** when the _Key File Options -> Provide a Path_ option is selected.
+* **`--service-account-p12-key-file-server-location`** The absolute filesystem path on the LiveData Migrator server of your service account key file in P12 format. You can either [create a GCS service account key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys) or [use an existing one](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#listing_service_account_keys).  
+This is referenced in the UI as **Key File** when the _Key File Options -> Provide a Path_ option is selected.
+* **`--service-account-json-key-file`** The absolute filesystem path on the host running the LiveData Migrator CLI of your service account key file in JSON format. Only use this parameter if you are running the LiveData Migrator CLI on a different host to your LiveData Migrator server.
+* **`--service-account-p12-key-file`** The absolute filesystem path on the host running the LiveData Migrator CLI of your service account key file in P12 format. Only use this parameter if you are running the LiveData Migrator CLI on a different host to your LiveData Migrator server.
+
+#### Example
+
+```text
+filesystem update gcs --file-system-id gcsAgent --bucket-name myGcsBucket --service-account-p12-key-file-server-location /user/hdfs/targetStorage/myAccountKey.p12 --service-account-email user@mydomain.com
+```
+
+----
+
+### `filesystem update hdfs`
+
+Update either a source or target Hadoop Distributed File System using the `filesystem update hdfs` command.
+
+```text title="Update a Hadoop Distributed File System"
+SYNOPSYS
+        filesystem update hdfs [--file-system-id] string
+                            [[--default-fs] string]
+                            [[--user] string]
+                            [[--kerberos-principal] string]
+                            [[--kerberos-keytab] string]
+                            [--source]
+                            [[--properties-files] list]
+                            [[--properties] string]
+
+OPTIONS
+        --file-system-id  string
+                Name of the filesystem
+                [Mandatory]
+
+        --default-fs  string
+
+                [Optional, default = <none>]
+
+        --user  string
+                FileSystem username to perform migration actions as
+                [Optional, default = <none>]
+
+        --kerberos-principal  string
+                Kerberos principal to authenticate with and perform migration actions as
+                [Optional, default = <none>]
+
+        --kerberos-keytab  string
+                Kerberos keytab to use when authenticating the provided kerberos principal
+                [Optional, default = <none>]
+
+        --source        Add this filesystem as the source for migrations
+                [Optional, default = false]
+
+        --properties-files  list
+                Load properties from these files
+                [Optional, default = <none>]
+
+        --properties  string
+                Override properties in comma separated key/value string e.g. --properties property-one=value-one,\"property-two=value-one,value-two\"
+                [Optional, default = <nothing>]
+```
+
+#### Mandatory Parameters
+
+* **`--file-system-id`** The identifier of the file system resource to update. This is referenced in the UI as **Storage Name**.
+
+#### Optional Parameters
+
+:::important Kerberos: Cross-realm authentication required between source and target HDFS
+[Cross-realm authentication](https://web.mit.edu/kerberos/krb5-1.5/krb5-1.5.4/doc/krb5-admin/Cross_002drealm-Authentication.html) is required in the following scenario:
+
+* The Migration will occur between a source and target HDFS.
+* Kerberos is enabled on both clusters.
+
+See the links below for guidance for common Hadoop distributions:
+
+* [CDH](https://docs.cloudera.com/documentation/enterprise/6/6.3/topics/cm_sg_kdc_def_domain_s2.html)
+* [CDP](https://docs.cloudera.com/cdp-private-cloud-base/7.1.5/security-kerberos-authentication/topics/cm-security-kerberos-authentication-kdc-cross-realm-trust.html)
+* [Red Hat](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system-level_authentication_guide/using_trusts) (Unmanaged)
+* [HDP](https://community.cloudera.com/t5/Community-Articles/Kerberos-cross-realm-trust-for-distcp/ta-p/245590)
+:::
+
+* **`--default-fs`** A string that defines how LiveData Migrator accesses HDFS. This is referenced in the UI as **Default FS**.  
+  It can be specified in a number of forms:
+  1. As a single HDFS URI, such as `hdfs://192.168.1.10:8020` (using an IP address) or `hdfs://myhost.localdomain:8020` (using a hostname).
+  1. As an HDFS URI that references a nameservice ID defined in the cluster properties, like `hdfs://mynameservice`, where there is a configuration property for the cluster that defines the value of the `dfs.nameservices` value to include that nameservice ID, like `mynameservice` and all required configuration properties for that nameservice, like `dfs.ha.namenodes.mynameservice`, `dfs.namenode.rpc-address.mynameservice.nn1`, and `dfs.namenode.http-address.mynameservice.nn1`, etc.
+* **`--user`** The name of the HDFS user to be used when performing operations against the file system. In environments where Kerberos is disabled, this user must be the HDFS super user, such as `hdfs`.
+* **`--kerberos-principal`** The Kerberos principal to authenticate with and perform migrations as. This principal should map to the [HDFS super user](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/HdfsPermissionsGuide.html#The_Super-User) using [auth_to_local](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/SecureMode.html#Mapping_from_Kerberos_principals_to_OS_user_accounts) rules.
+* **`--kerberos-keytab`** The Kerberos keytab containing the principal defined for the `--kerberos-principal` parameter. This must be accessible to the local system user running the LiveData Migrator service (default is `hdfs`).
+* **`--source`** Provide this parameter to use the file system resource created as a source.  This is referenced in the UI when configuring the _Unknown source_.
+* **`--properties-files`** Reference a list of existing properties files that contain Hadoop configuration properties in the format used by `core-site.xml` or `hdfs-site.xml`.  This is referenced in the UI as **Provide a path to files** under the _Additional Configuration_ option.
+* **`--properties`** Specify properties to use in a comma-separated key/value list. This is referenced in the UI as **Additional Configuration** under the _Additional Configuration_ option.
+
+##### Properties files are required for NameNode HA
+
+If your Hadoop cluster has [NameNode HA enabled](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/HDFSHighAvailabilityWithQJM.html), you must provide the local filesystem path to the properties files that define the configuration for the nameservice ID.
+
+**Source HDFS filesystem**: These configuration files will likely be in a default location depending on the distribution of the Hadoop cluster.
+
+**Target HDFS filesystem**: Ensure that the target Hadoop cluster configuration is available on your LiveData Migrator host's local filesystem.
+
+* For the UI, use **Provide a path to files** under the _Additional Configuration_ option and define the directory containing the `core-site.xml` and `hdfs-site.xml` files.
+
+  ```text title="Example for path containing source cluster configuration"
+  /etc/hadoop/conf
+  ```
+
+  ```text title="Example for path containing target cluster configuration"
+  /etc/targetClusterConfig
+  ```
+
+  Alternatively, define the absolute filesystem paths to these files:
+
+  ```text title="Example for absolute paths to source cluster configuration files"
+  /etc/hadoop/conf/core-site.xml
+  /etc/hadoop/conf/hdfs-site.xml
+  ```
+
+  ```text title="Example for absolute paths to target cluster configuration files"
+  /etc/targetClusterConfig/core-site.xml
+  /etc/targetClusterConfig/hdfs-site.xml
+  ```
+
+* For the CLI/API, use the `--properties-files` parameter and define the absolute paths to the `core-site.xml` and `hdfs-site.xml` files (see the [Examples](#examples) section for CLI usage of this parameter).
+
+#### Examples
+
+##### HDFS as source
+
+```text title="Example for source NameNode HA cluster"
+filesystem add hdfs --file-system-id mysource --source --default-fs hdfs://sourcenameservice --properties-files /etc/hadoop/conf/core-site.xml,/etc/hadoop/conf/hdfs-site.xml
+```
+
+```text title="Example for source NameNode HA cluster with Kerberos enabled"
+filesystem add hdfs --file-system-id mysource --source --default-fs hdfs://sourcenameservice --properties-files /etc/hadoop/conf/core-site.xml,/etc/hadoop/conf/hdfs-site.xml --kerberos-keytab /etc/security/keytabs/hdfs.headless.keytab --kerberos-principal hdfs@SOURCEREALM.COM
+```
+
+##### HDFS as target
+
+:::note
+When specifying a HDFS filesystem as a target, the property files for the target cluster must exist on the local filesystem and be accessible to the LiveData Migrator system user.
+:::
+
+```text title="Example for target NameNode HA cluster with Kerberos enabled"
+filesystem add hdfs --file-system-id mytarget --default-fs hdfs://targetnameservice --properties-files /etc/targetClusterConfig/core-site.xml,/etc/targetClusterConfig/hdfs-site.xml --kerberos-keytab /etc/security/keytabs/hdfs.headless.keytab --kerberos-principal hdfs@SOURCEREALM.COM
+```
+
+```text title="Example for target single NameNode cluster"
+filesystem add hdfs --file-system-id mytarget --default-fs hdfs://namenode.targetdomain:8020 --user hdfs
+```
+
 ## Exclusion Commands
 
 ----
@@ -725,7 +1094,7 @@ OPTIONS
 
 * **`--exclusion-id`** The identifier for the exclusion policy. This is referenced in the UI as **Name**.
 * **`--description`** A user-friendly description for the policy. This is referenced in the UI as **Description**.
-* **`--before-date`** An [ISO formatted](https://www.digi.com/resources/documentation/digidocs/90001437-13/reference/r_iso_8601_date_format.htm) date and time, which can include an offset for a particular time zone. This is referenced in the UI as **Select Date**.
+* **`--before-date`** An [ISO formatted](https://www.digi.com/resources/documentation/digidocs/90001437-13/reference/r_iso_8601_date_format.htm) date and time, which can include an offset for a particular time zone. This is referenced in the UI as **TBA**.
 
 #### Example
 
@@ -1089,10 +1458,6 @@ OPTIONS
 
         --auto-start
                 [Optional, default = false]
-
-        --scanOnly
-                Flags the migration as a non-live migration. The migration will not check the source for modifications during data transfer.
-                [Optional, default = false]
 ```
 
 #### Mandatory Parameters
@@ -1111,7 +1476,6 @@ OPTIONS
      Every file is replaced, even if file size is identical on the target storage. This is referenced in the UI as **Overwrite**.
   1. **`com.wandisco.livemigrator2.migration.SkipIfSizeMatchActionPolicy`**  
      If the file size is identical between the source and target, the file is skipped. If it’s a different size, the whole file is replaced. This is referenced in the UI as **Skip if Size Match**.
-* **`--scanOnly`** Flags the migration as a [non-live migration](./create-migration.md/#create-a-non-live-migration).
 
 #### Example
 
@@ -1120,6 +1484,8 @@ migration add --path /repl1 --target mytarget –-migration-id myNewMigration --
 ```
 
 ----
+
+
 
 ### `migration run`
 
@@ -1285,14 +1651,10 @@ SYNOPSYS
 
 ### `hive agent add azure`
 
-Add a local or remote hive agent to connect to an [Azure SQL](https://docs.microsoft.com/en-gb/azure/azure-sql/azure-sql-iaas-vs-paas-what-is-overview) database using the `hive agent add azure` command.
+Add an Azure hive agent to connect to an [Azure SQL](https://docs.microsoft.com/en-gb/azure/azure-sql/azure-sql-iaas-vs-paas-what-is-overview) database using the `hive agent add azure` command.
 
-If your LiveData Migrator host can communicate directly with the Azure SQL database, then a local hive agent will be sufficient. Otherwise, consider using a remote hive agent.
-
-:::info remote deployments
-For a remote hive agent connection, specify a remote host (Azure VM, HDI cluster node) that will be used to communicate with the local LiveData Migrator server (constrained to a user-defined port).
-
-A small service will be deployed on this remote host so that the hive agent can migrate data to and/or from the Azure SQL database.
+:::info
+The Azure hive agent requires a ADLS Gen2 storage account and container name, this is only for the purposes of generating the correct location for the database. The container will not be accessed by the Hive agent and no data will be written to the container.
 :::
 
 ```text title="Add Azure SQL agent"
@@ -1314,19 +1676,11 @@ OPTIONS
 
         --database-user  string
                 Azure SQL database user
-                [Optional, default = <nothing>]
+                [Mandatory]
 
         --database-password  string
                 Azure SQL database password
-                [Optional, default = <nothing>]
-
-        --auth-method  azure-sqlauthentication-method
-                Azure SQL database connection authentication method (SQL_PASSWORD, AD_MSI, AD_INTEGRATED, AD_PASSWORD, ACCESS_TOKEN)
                 [Mandatory]
-
-        --client-id  string
-                Azure resource's clientId
-                [Optional, default = <nothing>]
 
         --storage-account  string
                 Azure storage account name
@@ -1347,97 +1701,16 @@ OPTIONS
         --insecure  boolean
                 use insecure connection to Azure
                 [Optional, default = <nothing>]
-
-        --host  string
-                host where remote hive agent will be deployed
-                [Optional, default = <nothing>]
-
-        --port  integer
-                port to use by remote hive agent
-                [Optional, default = <nothing>]
-
-        --autodeploy  boolean
-                automatically deploy remote agent. If specified, you must specify sshKey to connect.
-                [Optional, default = <none>]
-
-        --ssh-user  string
-                ssh user to use for authentication on remote host to perform automatic deployment
-                [Optional, default = <nothing>]
-
-        --ssh-key  file
-                ssh key to use for authentication on remote host to perform automatic deployment
-                [Optional, default = <nothing>]
-
-        --ssh-port  int
-                ssh port to use to perform automatic deployment
-                [Optional, default = 22]
-
-        --use-sudo      use sudo for privileged commands while performing remote installation
-                [Optional, default = false]
-
-        --ignore-host-checking  ignore strict host key checking for unknown hosts
-                [Optional, default = false]
 ```
 
 #### Mandatory Parameters
 
-:::info
-The Azure hive agent requires a ADLS Gen2 storage account and container name. This is only for the purposes of generating the correct location for the database. The container will not be accessed by the hive agent and no data will be written to the container.
-:::
-
 * **`--db-server-name`** The Azure SQL database server name. Only the name given to the server is required, the `.database.windows.net` suffix should be omitted.
 * **`--database-name`** The Azure SQL database name.
-* **`--storage-account`** The name of the ADLS Gen 2 storage account.
-* **`--container-name`** The name of the container in the ADLS Gen2 storage account.
-
-#### Authentication Parameters
-
-Choose one of the authentication methods listed and include the additional parameters required for the chosen method.
-
-* **`--auth-method`** The authentication method to use to connect to the Azure SQL server.  
-  The following methods can be used:
-  * `SQL_PASSWORD` - Provide a username and password to access the database.
-  * `AD_MSI` - Use a system-assigned or user-assigned [managed identity](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview#managed-identity-types).
-
-##### Required Parameters for SQL_PASSWORD
-
 * **`--database-user`** The user name to access the database.
 * **`--database-password`** The user password to access the database.
-
-##### Required Parameters for AD_MSI
-
-To use this method, the following pre-requirements must be met:
-
-* LiveData Migrator or the remote Azure hive agent must be installed on an [Azure resource with the managed identity assigned to it](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/qs-configure-portal-windows-vm). The host must also have [Azure Active Directory authentication](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/login-using-aad) enabled.
-* Your Azure SQL server must be enabled for [Azure Active Directory authentication](https://docs.microsoft.com/en-us/azure/azure-sql/database/authentication-aad-configure?tabs=azure-powershell).
-* You have [created a contained user in the Azure SQL database that is mapped to the Azure Active Directory resource](https://docs.microsoft.com/en-us/azure/azure-sql/database/authentication-aad-configure?tabs=azure-powershell#create-contained-users-mapped-to-azure-ad-identities) (where LiveData Migrator or the remote Azure hive agent is installed).
-  * The username of the contained user will depend on whether you are using a system-assigned or user-assigned identity.
-
-    ```text title="Azure SQL database command for a system-assigned managed identity"
-    CREATE USER "<azure_resource_name>" FROM EXTERNAL PROVIDER;
-    ALTER ROLE db_owner ADD MEMBER "<azure_resource_name>";
-    ```
-
-    The `<azure_resource_name>` is the name of the Azure resource where LiveData Migrator or remote Azure hive agent is installed (for example: `myAzureVM`).
-
-    ```text title="Azure SQL database command for a user-assigned managed identity"
-    CREATE USER <managed_identity_name> FROM EXTERNAL PROVIDER;
-    ALTER ROLE db_owner ADD MEMBER <managed_identity_name>;
-    ```
-
-    The `<managed_identity_name>` is the name of the user-assigned managed identity (for example: `myManagedIdentity`).
-
-Once all pre-requirements are met, see the [system-assigned identity](#system-assigned-identity) or [user-assigned identity](#user-assigned-identity) parameters.
-
-###### System-assigned identity
-
-No other parameters are required for a system-managed identity.
-
-###### User-assigned identity
-
-Specify the `--client-id` parameter:
-
-* **`--client-id`** The Client ID of your Azure managed identity.
+* **`--storage-account`** The name of the ADLS Gen 2 storage account.
+* **`--container-name`** The name of the container in the ADLS Gen2 storage account.
 
 #### Optional Parameters
 
@@ -1446,58 +1719,10 @@ Specify the `--client-id` parameter:
 * **`--hdi-version`** The [HDI](https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-component-versioning) version. This is relevant if you are intending to integrate your SQL server into a HDInsights cluster.
 * **`--insecure`** Define an insecure connection (SSL disabled) to the Azure SQL database server (default is `false`).
 
-#### Parameters for remote hive agents only
+#### Example
 
-* **`--host`** The host where the remote hive agent will be deployed.
-* **`--port`** The port for the remote hive agent to use on the remote host. Default is `5052`. This port is used to communicate with the local LiveData Migrator server.
-
-##### Parameters for automated deployment
-
-* **`--autodeploy`** The remote agent will be automatically deployed when this flag is used. If using this, the `--ssh-key` parameter must also be specified.
-* **`--ssh-user`** The SSH user to use for authentication on the remote host to perform automatic deployment (when using the `--autodeploy` parameter).
-* **`--ssh-key`** The absolute path to the SSH private key to use for authentication on the remote host to perform automatic deployment (when using the `--autodeploy` parameter).
-* **`--ssh-port`** The SSH port to use for authentication on the remote host to perform automatic deployment (when using the `--autodeploy` parameter). Default is port `22`.
-* **`--use-sudo`** All commands performed by the SSH user will use `sudo` on the remote host when performing automatic deployment (using the `--autodeploy` parameter).
-* **`--ignore-host-checking`** Ignore [strict host key checking](https://www.redhat.com/sysadmin/linux-knownhosts-failures) when performing the automatic deployment (using the `--autodeploy` parameter).
-
-##### Steps for manual deployment
-
-If you do not wish to use the `--autodeploy` function, follow these steps to deploy a remote hive agent for Azure SQL manually:
-
-1. Transfer the remote server installer to your remote host (Azure VM, HDI cluster node):
-
-   ```text title="Example of secure transfer from local to remote host"
-   scp /opt/wandisco/hivemigrator/hivemigrator-remote-server-installer.sh myRemoteHost:~
-   ```
-
-1. On your remote host, run the installer as root (or sudo) user in silent mode:
-
-   ```text
-   ./hivemigrator-remote-server-installer.sh -- --silent
-   ```
-
-1. On your remote host, start the remote server service:
-
-   ```text
-   service hivemigrator-remote-server start
-   ```
-
-1. On your local host, run the `hive agent add azure` command without using `--autodeploy` and its related parameters to configure your remote hive agent.
-
-   See the **Example for remote Azure SQL deployment - manual** example below for further guidance.
-
-#### Examples
-
-```text title="Example for local Azure SQL deployment with SQL username/password"
-hive agent add azure --name azureAgent --db-server-name mysqlserver --database-name mydb1 --auth-method SQL_PASSWORD --database-user azureuser --database-password mypassword --storage-account myadls2 --container-name mycontainer --root-folder /hive/warehouse --hdi-version 3.6
-```
-
-```text title="Example for remote Azure SQL deployment with System-assigned managed identity - automated"
-hive agent add azure --name azureRemoteAgent --db-server-name mysqlserver --database-name mydb1 --auth-method AD_MSI --storage-account myadls2 --container-name mycontainer --root-folder /hive/warehouse --hdi-version 3.6 --autodeploy --ssh-user root --ssh-key /root/.ssh/id_rsa --ssh-port 22 --host myRemoteHost.example.com --port 5052
-```
-
-```text title="Example for remote Azure SQL deployment with User-assigned managed identity - manual"
-hive agent add azure --name azureRemoteAgent --db-server-name mysqlserver --database-name mydb1 --auth-method AD_MSI --client-id b67f67ex-ampl-e2eb-bd6d-client9385id --storage-account myadls2 --container-name mycontainer --root-folder /hive/warehouse --hdi-version 3.6 --host myRemoteHost.example.com --port 5052
+```text
+hive agent add azure --name azureAgent --db-server-name mysqlserver --database-name mydb1 --database-user azureuser --database-password mypassword --storage-account myadls2 --container-name mycontainer --root-folder /hive/warehouse --hdi-version 3.6
 ```
 
 ----

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -454,6 +454,75 @@ filesystem add hdfs --file-system-id mytarget --default-fs hdfs://namenode.targe
 
 ----
 
+### `filesystem add local`
+
+Add a Hadoop Compatible local filesystem as either a migration target or source using the `filesystem add local` command.
+
+```text title="Add a Local FileSystem via HCFS API."
+SYNOPSYS
+        filesystem add local [--file-system-id] string
+                                       [[--fs-root] string]
+                                       [--source]
+                                       [--scan-only]
+                                       [[--properties-files] list]
+                                       [[--properties] string]
+
+OPTIONS
+        --file-system-id  string
+                Name of the filesystem
+                [Mandatory]
+
+        --fs-root  string
+                Location in the local filesystem to chroot to
+                [Optional, default = <none>]
+
+        --source
+                Add this filesystem as a source for migrations
+                [Optional, default = false]
+
+        --scan-only
+                [Optional, default = false]
+
+        --properties-files  list
+                Load properties from these files
+                [Optional, default = <nothing>]
+
+        --properties  string
+                Override properties in comma separated key/value string e.g. --properties property-one=value-one,\"property-two=value-one,value-two\"
+                [Optional, default = <nothing>]
+```
+
+#### Mandatory Parameters
+
+* **`--file-system-id`** The identifier to give the new file system resource. This is referenced in the UI as **Storage Name**.
+
+#### Optional Parameters
+
+* **`--fs-root`** The directory in the local filesystem to scan for data or send data to, depending on whether the filesystem is defined as a source or a target. Should be supplied using the full directory path from the root.
+* **`--source`** Provide this parameter to use the file system resource created as a source.  This is referenced in the UI when configuring the _Unknown source_.
+* **`--scan-only`** Provide this parameter to create a non-live source filesysytem for use in non-live migrations. Requires `--source`.
+* **`--properties-files`** Reference a list of existing properties files, each that contains Hadoop configuration properties in the format used by `core-site.xml` or `hdfs-site.xml`.
+* **`--properties`** Specify properties to use in a comma-separated key/value list.
+
+:::note
+  If no `fs-root` is specified, the file path will default to the root of your system.
+:::
+
+#### Examples
+
+##### Local filesystem as source
+
+```text
+filesystem add local --file-system-id mytarget --fs-root ./tmp --source
+```
+##### Local filesystem as a target
+
+```text
+filesystem add local --file-system-id mytarget --fs-root ./Users/username/destinationfolder/
+```
+
+----
+
 ### `filesystem add s3a`
 
 Add an S3 bucket as a target file system using the `filesystem add s3a` command. This method also supports IBM COS buckets.
@@ -890,9 +959,6 @@ OPTIONS
 
 * **`--file-system-id`** The identifier of the file system resource to update. This is referenced in the UI as **Storage Name**.
 
-
-
-
 #### Optional Parameters
 
 * **`--bucket-name`** The bucket name of a Google Cloud Storage account. This is referenced in the UI as **Bucket Name**.
@@ -1039,11 +1105,11 @@ If your Hadoop cluster has [NameNode HA enabled](https://hadoop.apache.org/docs/
 ##### HDFS as source
 
 ```text title="Example for source NameNode HA cluster"
-filesystem add hdfs --file-system-id mysource --source --default-fs hdfs://sourcenameservice --properties-files /etc/hadoop/conf/core-site.xml,/etc/hadoop/conf/hdfs-site.xml
+filesystem update hdfs --file-system-id mysource --source --default-fs hdfs://sourcenameservice --properties-files /etc/hadoop/conf/core-site.xml,/etc/hadoop/conf/hdfs-site.xml
 ```
 
 ```text title="Example for source NameNode HA cluster with Kerberos enabled"
-filesystem add hdfs --file-system-id mysource --source --default-fs hdfs://sourcenameservice --properties-files /etc/hadoop/conf/core-site.xml,/etc/hadoop/conf/hdfs-site.xml --kerberos-keytab /etc/security/keytabs/hdfs.headless.keytab --kerberos-principal hdfs@SOURCEREALM.COM
+filesystem update hdfs --file-system-id mysource --source --default-fs hdfs://sourcenameservice --properties-files /etc/hadoop/conf/core-site.xml,/etc/hadoop/conf/hdfs-site.xml --kerberos-keytab /etc/security/keytabs/hdfs.headless.keytab --kerberos-principal hdfs@SOURCEREALM.COM
 ```
 
 ##### HDFS as target
@@ -1053,12 +1119,177 @@ When specifying a HDFS filesystem as a target, the property files for the target
 :::
 
 ```text title="Example for target NameNode HA cluster with Kerberos enabled"
-filesystem add hdfs --file-system-id mytarget --default-fs hdfs://targetnameservice --properties-files /etc/targetClusterConfig/core-site.xml,/etc/targetClusterConfig/hdfs-site.xml --kerberos-keytab /etc/security/keytabs/hdfs.headless.keytab --kerberos-principal hdfs@SOURCEREALM.COM
+filesystem update hdfs --file-system-id mytarget --default-fs hdfs://targetnameservice --properties-files /etc/targetClusterConfig/core-site.xml,/etc/targetClusterConfig/hdfs-site.xml --kerberos-keytab /etc/security/keytabs/hdfs.headless.keytab --kerberos-principal hdfs@SOURCEREALM.COM
 ```
 
 ```text title="Example for target single NameNode cluster"
-filesystem add hdfs --file-system-id mytarget --default-fs hdfs://namenode.targetdomain:8020 --user hdfs
+filesystem update hdfs --file-system-id mytarget --default-fs hdfs://namenode.targetdomain:8020 --user hdfs
 ```
+
+----
+
+### `filesystem update local`
+
+Update a target or source local filesystem using the `filesystem update local` command.
+
+```text title="Update a Local FileSystem via HCFS API."
+SYNOPSYS
+        filesystem update local [--file-system-id] string
+                                       [[--fs-root] string]
+                                       [--source]
+                                       [--scan-only]
+                                       [[--properties-files] list]
+                                       [[--properties] string]
+
+OPTIONS
+        --file-system-id  string
+                Name of the filesystem
+                [Mandatory]
+
+        --fs-root  string
+                Location in the local filesystem to chroot to
+                [Optional, default = <none>]
+
+        --source
+                Add this filesystem as a source for migrations
+                [Optional, default = false]
+
+        --scan-only
+                [Optional, default = false]
+
+        --properties-files  list
+                Load properties from these files
+                [Optional, default = <nothing>]
+
+        --properties  string
+                Override properties in comma separated key/value string e.g. --properties property-one=value-one,\"property-two=value-one,value-two\"
+                [Optional, default = <nothing>]
+```
+
+#### Mandatory Parameters
+
+* **`--file-system-id`** The identifier of the file system resource to update. This is referenced in the UI as **Storage Name**.
+
+#### Optional Parameters
+
+* **`--fs-root`** The directory in the local filesystem to scan for data or send data to, depending on whether the filesystem is defined as a source or a target. Should be supplied using the full directory path from the root.
+* **`--source`** Provide this parameter to use the file system resource created as a source.  This is referenced in the UI when configuring the _Unknown source_.
+* **`--scan-only`** Provide this parameter to create a non-live source filesysytem for use in non-live migrations. Requires `--source`.
+* **`--properties-files`** Reference a list of existing properties files, each that contains Hadoop configuration properties in the format used by `core-site.xml` or `hdfs-site.xml`.
+* **`--properties`** Specify properties to use in a comma-separated key/value list.
+
+#### Examples
+
+##### Local filesystem as source
+
+```text
+filesystem update local --file-system-id mytarget --fs-root ./tmp --source
+```
+##### Local filesystem as a target
+
+```text
+filesystem update local --file-system-id mytarget --fs-root ./Users/username/destinationfolder/
+```
+
+----
+
+### `filesystem update s3a`
+
+Update an S3 bucket target file system using the `filesystem update s3a` command. This method also supports IBM COS buckets.
+
+```text tile="Update an S3 file system"
+SYNOPSYS
+        filesystem update s3a [--file-system-id] string
+                           [--bucket-name] string
+                           [[--access-key] string]
+                           [[--secret-key] string]
+                           [--credentials-provider] string
+                           [[--properties-files] list]
+                           [[--properties] list]
+
+OPTIONS
+        --file-system-id  string
+
+                [Mandatory]
+
+        --bucket-name  string
+
+                [Optional, default = <none>]
+
+        --access-key  string
+
+                [Optional, default = <none>]
+
+        --secret-key  string
+
+                [Optional, default = <none>]
+
+        --credentials-provider  string
+
+                [Optional, default = <none>]
+
+        --properties-files  list
+                Load properties from these files
+                [Optional, default = <none>]
+
+        --properties  string
+                Override properties in comma separated key/value string e.g. --properties property-one=value-one,\"property-two=value-one,value-two\"
+                [Optional, default = <none>]
+```
+
+#### Mandatory Parameters
+
+* **`--file-system-id`** The identifier for file system resource to update. This is referenced in the UI as **Storage Name**.
+
+#### Optional parameters
+
+* **`--bucket-name`** The name of your S3 bucket. This is referenced in the UI as **Bucket Name**.
+* **`--credentials-provider`** The Java class name of a credentials provider for authenticating with the S3 endpoint. This is referenced in the UI as **Credentials Provider**. This is not a required parameter when adding an IBM COS bucket through the UI.  
+  The Provider options available include:
+  * **`org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider`**
+
+    Use this provider to offer credentials as an access key and secret access key with the `--access-key` and `--secret-key` Parameters.
+
+  * **`com.amazonaws.auth.InstanceProfileCredentialsProvider`**
+
+    Use this provider when running LiveData Migrator on an EC2 instance that has [been assigned an IAM role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html) with policies that allow it to access the S3 bucket.
+
+  * **`com.amazonaws.auth.DefaultAWSCredentialsProviderChain`**
+
+    A commonly-used credentials provider chain that looks for credentials in this order:
+
+    * Environment Variables - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or `AWS_ACCESS_KEY` and `AWS_SECRET_KEY`.
+    * Java System Properties - `aws.accessKeyId` and `aws.secretKey`.
+    * Web Identity Token credentials from the environment or container.
+    * Credential profiles file at the default location (`~/.aws/credentials`) shared by all AWS SDKs and the AWS CLI.
+    * Credentials delivered through the Amazon EC2 container service if `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable is set and security manager has permission to access the variable.
+    * Instance profile credentials delivered through the Amazon EC2 metadata service.
+* **Endpoint** (UI & IBM COS only): This is required for an IBM COS bucket, if one was not already specified for the filesystem you are updating. IBM provide a list of available endpoints that can be found in their [public documentation](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-endpoints#endpoints-region).
+* **`--access-key`** When using the `org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider` credentials provider, specify the access key with this parameter. This is referenced in the UI as **Access Key**. This is a required parameter for an IBM COS bucket if one was not already specified in the filesystem you're updating.
+* **`--secret-key`** When using the `org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider` credentials provider, specify the secret key using this parameter. This is referenced in the UI as **Secret Key**. This is a required parameter for an IBM COS bucket if one was not already specified in the filesystem you're updating.
+* **`--properties-files`** Reference a list of existing properties files, each that contains Hadoop configuration properties in the format used by `core-site.xml` or `hdfs-site.xml`.
+* **`--properties`** Specify properties to use in a comma-separated key/value list.
+
+#### S3a Properties
+
+:::info
+When adding properties via the UI or API, for example to set a custom `fs.s3a.endpoint`, it is required to also set the following properties manually. They are added by default when using the CLI.
+:::
+
+* **`fs.s3a.impl`** (default `org.apache.hadoop.fs.s3a.S3AFileSystem`): The implementation class of the S3A Filesystem.
+* **`fs.AbstractFileSystem.s3a.impl`** (default `org.apache.hadoop.fs.s3a.S3A`): The implementation class of the S3A AbstractFileSystem.
+* **`fs.s3a.user.agent.prefix`** (default `WANdisco/LiveDataMigrator`): Sets a custom value that will be pre-pended to the User-Agent header sent in
+    HTTP requests to the S3 back-end by S3AFileSystem.
+* **`fs.s3a.impl.disable.cache`** (default `true`): Disables the S3 file system cache when set to 'true'.
+* **`fs.hadoop.tmp.dir`** (default `tmp`): The parent directory for other temporary directories.
+
+#### Example
+
+```text
+filesystem update s3a --file-system-id mytarget --bucket-name mybucket1 --credentials-provider org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider --access-key B6ZAI18Z3UIO002Y777A --secret-key OP87Chokisf4hsTP0Q5j95yI904lT7AaDBGJpp0D
+```
+
+----
 
 ## Exclusion Commands
 

--- a/docs/create-migration.md
+++ b/docs/create-migration.md
@@ -56,6 +56,6 @@ Follow the command links to learn how to set the parameters and see examples.
 
 ### Create a non-live migration
 
-It's possible to create a migration that does not track client activity: if files are changed during the migration process, they will not be re-scanned by LiveData Migrator.
+Create a non-live migration if you do not want LiveData Migrator to scan for changes to your data during a migration. These migrations do not require you to have write access to the source filesystem, nor do they require you to operate the migration as the `hdfs` user.
 
-For more information, see [create a non-live migration](./non-live-migration.md).
+To create a non-live migration, see [create a non-live migration](./non-live-migration.md).

--- a/docs/create-migration.md
+++ b/docs/create-migration.md
@@ -53,35 +53,9 @@ Follow the command links to learn how to set the parameters and see examples.
 
    [`migration run`](./command-reference.md#migration-run)
 
+
 ### Create a non-live migration
 
-A non-live migration is a migration that does not track client activity: if files are changed during the migration process, they will not be re-scanned by LiveData Migrator. There are two ways to create a non-live migration through the CLI:
+It's possible to create a migration that does not track client activity: if files are changed during the migration process, they will not be re-scanned by LiveData Migrator.
 
-1. Start a migration with a [non-live source file system](#create-a-non-live-source-file-system)
-1. Specify the [`scanOnly` flag](#specify-the-scanonly-flag-during-migration-creation) during migration creation
-
-:::note
-A non-live migration does not read events from the source file system, and does not write a [marker file](./configuration-ldm.md/#hdfs-marker-storage) to the source file system. Once the scan of the source file system completes (to determine which files and directories are to be migrated), the migration will enter a `COMPLETED` [data migration state](./manage-migrations.md/#data-migration-states) and carry out no further scanning.
-:::
-
-#### Create a non-live source file system
-
-LiveData Migrator will only perform *read* tasks on a non-live source, and will not check the source for modifications to data during transfer. Any migration that uses a non-live source will automatically become a non-live migration, and will have the `scanOnly` flag applied.
-
-To create a non-live source, add the `scanOnly` flag during source creation:
-
-```text="Code"
-filesystem add hdfs --source --scanOnly ...
-```
-
-:::note
-The account used to connect to a non-live source only requires read access. Write access is not necessary.
-:::
-
-#### Specify the scanOnly flag during migration creation
-
-To create a non-live migration without creating a non-live source file system, simply add the `scanOnly` flag during migration creation:
-
-```text="Code"
-migration add --scanOnly ...
-```
+For more information, see [create a non-live migration](./non-live-migration.md).

--- a/docs/non-live-migration.md
+++ b/docs/non-live-migration.md
@@ -1,0 +1,66 @@
+---
+id: non-live-migration
+title: Create a Non-Live Migration
+sidebar_label: Create a non-live migration
+---
+
+A non-live migration is a migration that does not track client activity: if files are changed during the migration process, they will not be re-scanned by LiveData Migrator.
+
+:::note
+A non-live migration does not track events from the source file system, and does not write a [marker file](./configuration-ldm.md/#hdfs-marker-storage) to the source file system. Once the scan of the source file system completes (to determine which files and directories are to be migrated), the migration will enter a `COMPLETED` [data migration state](./manage-migrations.md/#data-migration-states) and carry out no further scanning.
+
+This means you can perform non-live migrations without write access, and without the need to operate the migration as the `hdfs` user.
+:::
+
+## Create a non-live migration
+
+Non-live migrations may be created through the UI or through the CLI.
+
+### Create a non-live migration with the UI
+
+To create a non-live migration through the CLI, simply deselect the "Live Migration" option when creating a migration. Unlike a live migration, this migration will not state that it is live. When in progress, the migration will inform you that you must rerun the migration to see new changes.
+
+### Create a non-live migration with the CLI
+
+A non-live migration is a migration that does not track client activity: if files are changed during the migration process, they will not be re-scanned by LiveData Migrator. There are two ways to create a non-live migration through the CLI:
+
+1. Start a migration with a [non-live source file system](#create-a-non-live-source)
+1. Specify the `scanOnly` flag during migration creation:
+
+```text="Code"
+migration add --scanOnly ...
+```
+
+:::note
+A non-live migration does not read events from the source file system, and does not write a [marker file](./configuration-ldm.md/#hdfs-marker-storage) to the source file system. Once the scan of the source file system completes (to determine which files and directories are to be migrated), the migration will enter a `COMPLETED` [data migration state](./manage-migrations.md/#data-migration-states) and carry out no further scanning.
+:::
+
+## Create a non-live source
+
+A non-live source is a filesystem that is not tracked by LiveData Migrator for changes during a migration.
+
+:::note
+Any migration created from a non-live source via the CLI will become a non-live migration by default, whereas the UI will uncheck the "live migration" option by default and prevent it from being enabled.
+:::
+
+Non-live sources may be created through the UI or through the CLI.
+
+### Create a non-live source with the UI
+
+To create a non-live source, simply uncheck the "Migrate Live Events" box during source creation.
+
+When creating a migration from a non-live source, "Live Migration" will be unchecked by default and cannot be enabled.
+
+### Create a non-live source file system with the CLI
+
+LiveData Migrator will only perform *read* tasks on a non-live source, and will not check the source for modifications to data during transfer. Any migration that uses a non-live source will automatically become a non-live migration, and will have the `scanOnly` flag applied.
+
+To create a non-live source, add the `scanOnly` flag during source creation:
+
+```text="Code"
+filesystem add hdfs --source --scanOnly ...
+```
+
+:::note
+The account used to connect to a non-live source only requires read access. Write access is not necessary.
+:::

--- a/docs/non-live-migration.md
+++ b/docs/non-live-migration.md
@@ -4,25 +4,25 @@ title: Create a Non-Live Migration
 sidebar_label: Create a non-live migration
 ---
 
-A non-live migration is a migration that does not track client activity: if files are changed during the migration process, they will not be re-scanned by LiveData Migrator.
+A non-live migration is a migration that does not track activity in the source filesystem. LiveData Migrator will not scan your data for updates during non-live migrations.
 
 :::note
-A non-live migration does not track events from the source file system, and does not write a [marker file](./configuration-ldm.md/#hdfs-marker-storage) to the source file system. Once the scan of the source file system completes (to determine which files and directories are to be migrated), the migration will enter a `COMPLETED` [data migration state](./manage-migrations.md/#data-migration-states) and carry out no further scanning.
+A non-live migration does not track events from the source file system, and does not write a [marker file](./configuration-ldm.md/#hdfs-marker-storage) to the source file system. Once the scan of the source file system completes (to determine which files and directories are to be migrated), the migration will enter a `COMPLETED` [data migration state](./manage-migrations.md/#data-migration-states) and won't perform any further scans.
 
 This means you can perform non-live migrations without write access, and without the need to operate the migration as the `hdfs` user.
 :::
 
 ## Create a non-live migration
 
-Non-live migrations may be created through the UI or through the CLI.
+You can create a non-live migration with either the UI or the CLI.
 
 ### Create a non-live migration with the UI
 
-To create a non-live migration through the CLI, simply deselect the "Live Migration" option when creating a migration. Unlike a live migration, this migration will not state that it is live. When in progress, the migration will inform you that you must rerun the migration to see new changes.
+To create a non-live migration with the CLI, deselect the "Live Migration" option when creating a migration. Unlike a live migration, this migration won't display a "live" state in the UI. During a migration, the migration tells you that you must rerun it to see new changes.
 
 ### Create a non-live migration with the CLI
 
-A non-live migration is a migration that does not track client activity: if files are changed during the migration process, they will not be re-scanned by LiveData Migrator. There are two ways to create a non-live migration through the CLI:
+There are two ways to create a non-live migration through the CLI:
 
 1. Start a migration with a [non-live source file system](#create-a-non-live-source)
 1. Specify the `scanOnly` flag during migration creation:
@@ -32,7 +32,9 @@ migration add --scanOnly ...
 ```
 
 :::note
-A non-live migration does not read events from the source file system, and does not write a [marker file](./configuration-ldm.md/#hdfs-marker-storage) to the source file system. Once the scan of the source file system completes (to determine which files and directories are to be migrated), the migration will enter a `COMPLETED` [data migration state](./manage-migrations.md/#data-migration-states) and carry out no further scanning.
+Non-live migrations do not read events from the source file system or write [marker files](./configuration-ldm.md/#hdfs-marker-storage) to the source file system.
+
+Once the scan of the source file system (to determine which files and directories are to be migrated) completes, the migration will enter a `COMPLETED` [data migration state](./manage-migrations.md/#data-migration-states) and carry out no further scanning.
 :::
 
 ## Create a non-live source
@@ -40,20 +42,20 @@ A non-live migration does not read events from the source file system, and does 
 A non-live source is a filesystem that is not tracked by LiveData Migrator for changes during a migration.
 
 :::note
-Any migration created from a non-live source via the CLI will become a non-live migration by default, whereas the UI will uncheck the "live migration" option by default and prevent it from being enabled.
+Any migration created from a non-live source will become a non-live migration by default. When creating a migration from the UI in this case, it will uncheck the "live migration" option by default and prevent it from being enabled.
 :::
 
 Non-live sources may be created through the UI or through the CLI.
 
 ### Create a non-live source with the UI
 
-To create a non-live source, simply uncheck the "Migrate Live Events" box during source creation.
+To create a non-live source, uncheck the "Migrate Live Events" box during source creation.
 
 When creating a migration from a non-live source, "Live Migration" will be unchecked by default and cannot be enabled.
 
 ### Create a non-live source file system with the CLI
 
-LiveData Migrator will only perform *read* tasks on a non-live source, and will not check the source for modifications to data during transfer. Any migration that uses a non-live source will automatically become a non-live migration, and will have the `scanOnly` flag applied.
+LiveData Migrator will only perform *read* tasks on a non-live source. It will not check the source for modifications to data during transfer. Any migration that uses a non-live source will automatically become a non-live migration, and will have the `scanOnly` flag applied.
 
 To create a non-live source, add the `scanOnly` flag during source creation:
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -51,6 +51,10 @@ module.exports = {
             },
             {
               "type": "doc",
+              "id": "non-live-migration"
+            },
+            {
+              "type": "doc",
               "id": "configure-exclusions"
             },
 


### PR DESCRIPTION
I used the wrong branch, this is actually for DOCU-921:
https://jira.wandisco.com/browse/DOCU-921

I additionally updated filesystem add with new parameters in 1.10. I prior overestimated the amount of changes that needed to be made.

Documenting API capabilities seemed unnecessary as our API-reference just points the user to Swagger for reference and doesn't list any of the prior REST functions either