### PR TITLE
Documented migration path status command

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -2849,6 +2849,28 @@ notification email types remove MISSING_EVENTS,EVENTS_BEHIND,MIGRATION_AUTO_STOP
 
 ----
 
+### `migration path status`
+
+View all actions scheduled on a source filesystem in the specified path.
+
+```text title="Show information on the migration status of a path on the source filesystem"
+SYNOPSYS
+        migration path status [--source-path] string [--source] string
+```
+
+#### Mandatory Parameters
+
+* **`--source-path`** The path on the filesystem to review actions for. Supply a full directory.
+* **`--source`** The filesystem ID of the source system the path is in.
+
+#### Example
+
+```text
+migration path status --source-path /root/mypath/ --source mySource
+```
+
+----
+
 ### `notification email types show`
 
 Return a list of all available notification types to subscribe to.

--- a/docs/configure-storage.md
+++ b/docs/configure-storage.md
@@ -194,7 +194,7 @@ You can define multiple target file systems, which you can migrate to at the sam
 
 ## Check path status
 
-You can check a file path on one of your source filesystems to view any scheduled work to be performed on it.
+Check the status of a path on your source filesystem to view any scheduled work to be performed on it.
 
 ### Check path status in the UI
 
@@ -208,7 +208,7 @@ You will be shown information about the file, such as the migration it's associa
 
 ### Check path status through the CLI
 
-Use the [`migration path status` command](./command-reference.md#migration-path-status) to view information about a file path, such as the migration it's associated with, the target and file path it's expected to migrate to, and whether or not any work is scheduled on the file. 
+Use the [`migration path status` command](./command-reference.md#migration-path-status) to view information about a file path, such as the migration it's associated with, the target and file path it's expected to migrate to, and whether or not any work is scheduled on the file.
 
 ## Configure storage for one-time migrations
 

--- a/docs/configure-storage.md
+++ b/docs/configure-storage.md
@@ -143,7 +143,7 @@ Selecting to configure your _Target_ storage on the Storage panel, see the links
 
 ### Validate your source
 
-LiveData Migrator migrates data from a source filesystem. Validate that the correct source filesystem is registered or delete the existing one (you'll define a new source in the [Add File Systems](#add-file-systems) step).
+LiveData Migrator migrates data from a source filesystem. Verify that the correct source filesystem is registered or delete the existing one (you'll define a new source in the [Add File Systems](#add-file-systems) step).
 
 If Kerberos is enabled or your Hadoop configuration does not contain the information needed to connect to the Hadoop file system, use the [`filesystem auto-discover-source hdfs`](./command-reference.md#filesystem-auto-discover-source-hdfs) command to provide your Kerberos credentials and auto-discover your source HDFS configuration.
 
@@ -191,6 +191,24 @@ You can define multiple target file systems, which you can migrate to at the sam
 | [`filesystem list`](./command-reference.md#filesystem-list) | List of target file systems |
 | [`filesystem show`](./command-reference.md#filesystem-show) | Get target file system details |
 | [`filesystem types`](./command-reference.md#filesystem-types) | List the types of target file systems available |
+
+## Check path status
+
+You can check a file path on one of your source filesystems to view any scheduled work to be performed on it.
+
+### Check path status in the UI
+
+1. From the main LiveData Migrator dashboard, click the triple dot button next to one of your filesystems
+1. In the menu that appears, select **Path Status**
+1. Select a source filesystem from the **Select a source filesystem** dropdown menu
+1. Enter the full path of a file on the source filesystem
+1. Click **Search**
+
+You will be shown information about the file, such as the migration it's associated with, the target and file path it's expected to migrate to, and whether or not any work is scheduled on the file.
+
+### Check path status through the CLI
+
+Use the [`migration path status` command](./command-reference.md#migration-path-status) to view information about a file path, such as the migration it's associated with, the target and file path it's expected to migrate to, and whether or not any work is scheduled on the file. 
 
 ## Configure storage for one-time migrations
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -121,3 +121,11 @@ And the following setting determines the low watermark percentage:
 ```text title="Example"
 notifications.pending.region.clear.percent=50
 ```
+
+## Troubleshooting techniques
+
+Use these LiveData Migrator features to identify problems with migrations or filesystems.
+
+### Check path status
+
+You can [check the status of a file path](./configure-storage.md#check-path-status) in either the UI or the CLI to determine whether any work is scheduled on the file. 


### PR DESCRIPTION
As per https://jira.wandisco.com/browse/DOCU-1181

The command is actually [migration path status] rather than [migration path status show], which is great because the latter was redundant.

I also documented how to do this in the UI, as per https://jira.wandisco.com/browse/DOCU-1186