### PR TITLE
Update command-reference.md

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1948,7 +1948,7 @@ The following steps are required to enable Java Database Connectivity (JDBC) to 
 Additionally, use only one of the following parameters:
 
 :::important
-If the `--convert-to-delta` option is used, the `--default-fs-override` parameter must also be provided with the value set to `dbfs:`.
+If the `--convert-to-delta` option is used, the `--default-fs-override` parameter must also be provided with the value set to `dbfs:`, or a path inside the Databricks filesystem, for example `dbfs:/mount/externalStorage`.
 :::
 
 * **`--file-system-id`** The name of the filesystem that will be associated with this agent (for example: `myadls2` or `mys3bucket`). This will ensure any [path mappings](./create-path-mappings.md) are correctly linked between the filesystem and the agent. This is referenced in the UI as **Filesystem**.
@@ -1970,6 +1970,13 @@ If the `--convert-to-delta` option is used, the `--default-fs-override` paramete
     :::important
     Only use this option if you are performing [one-time migrations](./one-time-migration.md) for the underlying table data. The Databricks agent does not support continuous (live) updates of table data when transferring to Delta Lake on Databricks.
     :::
+
+- If a migration to Databricks runs without the **`--convert-to-delta`** option, then some migrated data may not be visible from the Databricks side. To avoid this issue, ensure that the value of `default-fs-override` is set to "`dbfs:`" with the value of `--fs-mount-point`.
+
+  **Example:**
+  ```
+  --default-fs-override dbfs:/mnt/mybucketname    
+  ```
 
 #### Parameters for remote hive agents only
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1948,7 +1948,7 @@ The following steps are required to enable Java Database Connectivity (JDBC) to 
 Additionally, use only one of the following parameters:
 
 :::important
-If the `--convert-to-delta` option is used, the `--default-fs-override` parameter must also be provided with the value set to `dbfs:`, or a path inside the Databricks filesystem, for example `dbfs:/mount/externalStorage`.
+If the `--convert-to-delta` option is used, the `--default-fs-override` parameter must also be provided with the value set to `dbfs:`, or a path inside the Databricks filesystem. For example, `dbfs:/mount/externalStorage`.
 :::
 
 * **`--file-system-id`** The name of the filesystem that will be associated with this agent (for example: `myadls2` or `mys3bucket`). This will ensure any [path mappings](./create-path-mappings.md) are correctly linked between the filesystem and the agent. This is referenced in the UI as **Filesystem**.


### PR DESCRIPTION
DOCU-1197 change:

From line 1974, requirement when running without converting to delta.

Ben suggested adding a fix, the requirement for which was raised in HVM-1375. We don't just support "dbfs" but also a specific mount point within the file system.