### PR TITLE
DOCU-1195 content and DOCU-1196 fix

### DIFF
--- a/docs/configure-storage.md
+++ b/docs/configure-storage.md
@@ -141,7 +141,7 @@ Selecting to configure your _Target_ storage on the Storage panel, see the links
 
 ### Delete target storages
 
-Delete a target storage from its **Storage Configuration** panel. Click the **Delete Storage** button. Before you can delete a target storage you must ensure that you first delete any associated migrations. See [Delete a migration](./manage-migrations#delete-a-migration).
+Delete a target storage from its **Storage Configuration** panel. Click the **Delete Storage** button. Before you can delete a target storage you must ensure that you first [delete any associated migrations](./manage-migrations#delete-a-migration).
 
 ## Configure storage with the CLI
 

--- a/docs/configure-storage.md
+++ b/docs/configure-storage.md
@@ -18,7 +18,7 @@ The Storage panel shows the filesystems LiveData Migrator uses as either a sourc
 Use the Storage panel to:
 
 * View and configure the source and target filesystems.
-* Add further targets.
+* Add or remove targets.
 * Add additional LiveData Migrator servers and [LiveData Plane](https://wandisco.github.io/wandisco-documentation/docs/quickstarts/preparation/get-started) servers.
 * Configure Amazon S3-compatible targets using the [Hadoop S3A configuration](http://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/index.html) exposed in the UI.
 * Connect to additional LiveData Migrator or LiveData Plane instances and configure their respective storages.
@@ -138,6 +138,10 @@ Selecting to configure your _Target_ storage on the Storage panel, see the links
 * [S3 / IBM Cloud Object Storage (S3)](./command-reference.md#s3a-mandatory-parameters)
 * [Google Cloud Storage](./command-reference.md#mandatory-parameters-3)
 * [HDFS](./command-reference/#mandatory-parameters-4)
+
+### Delete target storages
+
+Delete a target storage from its **Storage Configuration** panel. Click the **Delete Storage** button. Before you can delete a target storage you must ensure that you first delete any associated migrations. See [Delete a migration](./manage-migrations#delete-a-migration).
 
 ## Configure storage with the CLI
 

--- a/docs/manage-migrations.md
+++ b/docs/manage-migrations.md
@@ -135,5 +135,5 @@ The **Failed Operations** panel on LiveData UI's Migration screen provides a cou
   ```
 
 :::note
-Historical failure information may be garbage collected, so it may not be possible to show all failures. In this case a warning will appear that states' *"We're unable to show detailed results of failed operations. We only have detailed results from the most recent <number of available failures> results"*
+Historical failure information may be garbage collected, so it may not be possible to show all failures. In this case a warning will appear that states' *"We're unable to show detailed results of failed operations. We only have detailed results from the most recent [number of available failures] results"*
 :::


### PR DESCRIPTION
Fixed issue caused by DOCU-1196 change by replacing < with [ so that the element isn't parsed as a HTML tag.

For DOCU-1195
Added a "Delete Target" section to the Configure Storage page so that we can add the clarification about deleting migrations before being able to delete targets.